### PR TITLE
Pass an arbitrary to arbitrary-sequence-like instead of a generator

### DIFF
--- a/test/active/quickcheck2/arbitrary_test.cljc
+++ b/test/active/quickcheck2/arbitrary_test.cljc
@@ -1,7 +1,7 @@
 (ns active.quickcheck2.arbitrary-test
   (:require [clojure.test :refer :all]
             [active.quickcheck2.random :as random]
-            [active.quickcheck2.generator :refer [generate choose-int]]
+            [active.quickcheck2.generator :refer [generate]]
             [active.quickcheck2.tree :as tree]
             [active.quickcheck2.arbitrary :refer :all]))
 
@@ -14,32 +14,32 @@
     (is (tree/approx-valid-tree? 5 (test-generate
                                     (arbitrary-generator
                                      (arbitrary-sequence-like list
-                                                              choose-int)))))
+                                                              arbitrary-integer)))))
     (is (every? list? (take 100 (tree/to-list
                                  (test-generate
                                   (arbitrary-generator
                                    (arbitrary-sequence-like list
-                                                            choose-int)))))))
+                                                            arbitrary-integer)))))))
     (is (tree/approx-valid-tree? 5 (test-generate
                                     (arbitrary-generator
                                      (arbitrary-sequence-like vec
-                                                              choose-int)))))
+                                                              arbitrary-integer)))))
     (is (every? vector? (take 100 (tree/to-list
                                    (test-generate
                                     (arbitrary-generator
                                      (arbitrary-sequence-like vec
-                                                              choose-int)))))))))
+                                                              arbitrary-integer)))))))))
 
 (deftest arbitrary-list-works
   (testing "arbitrary-sequ-like produces tree of sequence"
     (is (tree/approx-valid-tree? 5 (test-generate
                                     (arbitrary-generator
-                                     (arbitrary-list choose-int)))))
+                                     (arbitrary-list arbitrary-integer)))))
     (is (every? list? (take 100 (tree/to-list
                                  (test-generate
                                   (arbitrary-generator
-                                   (arbitrary-list choose-int)))))))
+                                   (arbitrary-list arbitrary-integer)))))))
     (is (every? (partial every? int?) (take 100 (tree/to-list
                                                  (test-generate
                                                   (arbitrary-generator
-                                                   (arbitrary-list choose-int)))))))))
+                                                   (arbitrary-list arbitrary-integer)))))))))


### PR DESCRIPTION
Fixes arbitrary-test.
But I'm not sure if it fixes them /correctly/.